### PR TITLE
fix: resolve three bugs in loop, return, and command directory features

### DIFF
--- a/.opencode/commands/demo-return-chain.md
+++ b/.opencode/commands/demo-return-chain.md
@@ -1,0 +1,10 @@
+---
+description: Multi-step return chain - analyze, implement, verify
+subtask: true
+return:
+  - /demo-return $ARGUMENTS
+  - Review the implementation for correctness and edge cases
+  - Run the tests and fix any failures
+---
+First, create a detailed implementation plan for:
+$ARGUMENTS

--- a/.opencode/commands/demo-return.md
+++ b/.opencode/commands/demo-return.md
@@ -1,0 +1,10 @@
+---
+description: Demo return chaining - analyzes then implements
+subtask: true
+return:
+  - Challenge the analysis above. Look for edge cases and missed scenarios.
+  - Implement the fix for the issue found.
+---
+Review the following code and identify bugs, performance issues, or improvements:
+
+$ARGUMENTS

--- a/src/commands/loader.ts
+++ b/src/commands/loader.ts
@@ -9,8 +9,8 @@ export async function loadCommandFile(
 ): Promise<{ content: string; path: string } | null> {
   const home = Bun.env.HOME ?? "";
   const dirs = [
-    `${home}/.config/opencode/command`,
-    `${Bun.env.PWD ?? "."}/.opencode/command`,
+    `${home}/.config/opencode/commands`,
+    `${Bun.env.PWD ?? "."}/.opencode/commands`,
   ];
 
   for (const dir of dirs) {

--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -15,8 +15,8 @@ export async function buildManifest(): Promise<Record<string, CommandConfig>> {
   const manifest: Record<string, CommandConfig> = {};
   const home = Bun.env.HOME ?? "";
   const dirs = [
-    `${home}/.config/opencode/command`,
-    `${Bun.env.PWD ?? "."}/.opencode/command`,
+    `${home}/.config/opencode/commands`,
+    `${Bun.env.PWD ?? "."}/.opencode/commands`,
   ];
 
   for (const dir of dirs) {

--- a/src/features/returns.ts
+++ b/src/features/returns.ts
@@ -14,7 +14,6 @@ import {
   registerPendingResultCaptureByPrompt,
   registerPendingMainSessionCapture,
   setLastReturnType,
-  setPendingPromptReturn,
 } from "../core/state";
 import { getConfig } from "../commands/resolver";
 import { log } from "../utils/logger";
@@ -261,10 +260,9 @@ export async function executeReturn(
     // Track that we just executed a prompt
     setLastReturnType(sessionID, "prompt");
 
-    // Set pending for message-hooks injection (handles current LLM call)
-    setPendingPromptReturn(sessionID, item);
-
-    // Also persist via promptAsync (for history)
+    // promptAsync already persists the message as a real user message.
+    // No need to call setPendingPromptReturn — that would cause
+    // message-hooks to inject a duplicate copy.
     await client.session.promptAsync({
       path: { id: sessionID },
       body: { parts: [{ type: "text", text: item }] },

--- a/src/hooks/session-idle-hook.ts
+++ b/src/hooks/session-idle-hook.ts
@@ -17,7 +17,7 @@ import {
   hasPendingStackedPromptResponse,
   clearPendingStackedPromptResponse,
   setPendingStackedPromptResponse,
-  setPendingPromptReturn,
+
   setSubtaskParentSession,
   getSubtaskParentSession,
   consumePendingParentForPrompt,
@@ -201,11 +201,11 @@ export async function handleSessionIdle(sessionID: string) {
       log(`loop: unconditional loop, auto-continuing`);
     }
 
-    clearPendingEvaluation(sessionID);
+    clearPendingEvaluation(targetSessionID);
 
     if (decision === "continue") {
-      incrementLoopIteration(sessionID);
-      const state = getLoopState(sessionID);
+      incrementLoopIteration(targetSessionID);
+      const state = getLoopState(targetSessionID);
       if (state) {
         log(
           `loop: continuing iteration ${state.iteration}/${state.config.max}`
@@ -220,7 +220,7 @@ export async function handleSessionIdle(sessionID: string) {
 
           try {
             await client.session.promptAsync({
-              path: { id: sessionID },
+              path: { id: targetSessionID },
               body: {
                 parts: [
                   {
@@ -240,16 +240,16 @@ export async function handleSessionIdle(sessionID: string) {
           const cmdWithArgs = `/${state.commandName}${
             state.arguments ? " " + state.arguments : ""
           }`;
-          executeReturn(cmdWithArgs, sessionID).catch(console.error);
+          executeReturn(cmdWithArgs, targetSessionID).catch(console.error);
         }
         return;
       }
     } else {
       if (evalState.deferredReturns?.length) {
-        pushReturnStack(sessionID, [...evalState.deferredReturns]);
+        pushReturnStack(targetSessionID, [...evalState.deferredReturns]);
       }
       log(`loop: breaking loop, condition satisfied`);
-      clearLoop(sessionID);
+      clearLoop(targetSessionID);
     }
   }
 
@@ -319,14 +319,13 @@ export async function handleSessionIdle(sessionID: string) {
       executeReturn(next, targetSessionID).catch(console.error);
     } else {
       log(
-        `session.idle: setting pending prompt return: "${next.substring(0, 40)}..."`
+        `session.idle: executing prompt return: "${next.substring(0, 40)}..."`
       );
-      // Set pending prompt for message-hooks to inject into current LLM call
-      setPendingPromptReturn(targetSessionID, next);
       setLastReturnType(targetSessionID, "prompt");
 
-      // Also persist the message via promptAsync so it appears in history
-      // This is needed because injection into output.messages doesn't persist
+      // promptAsync persists the message as a real user message in history.
+      // No setPendingPromptReturn needed — that would cause message-hooks
+      // to inject a duplicate copy of the same prompt.
       client.session
         .promptAsync({
           path: { id: targetSessionID },

--- a/src/hooks/session-idle-hook.ts
+++ b/src/hooks/session-idle-hook.ts
@@ -182,7 +182,8 @@ export async function handleSessionIdle(sessionID: string) {
   }
 
   // 3. Check for loop evaluation response
-  const evalState = getPendingEvaluation(sessionID);
+  // Use targetSessionID (resolved parent) since eval state is stored under the parent session
+  const evalState = getPendingEvaluation(targetSessionID);
   if (evalState) {
     let decision: "break" | "continue" = "continue";
 

--- a/src/hooks/tool-hooks.ts
+++ b/src/hooks/tool-hooks.ts
@@ -23,6 +23,7 @@ import {
   getPendingResultCapture,
   captureSubtaskResult,
   setDeferredReturnPrompt,
+  deleteExecutedReturn,
 } from "../core/state";
 import { getConfig } from "../commands/resolver";
 import { log } from "../utils/logger";
@@ -282,6 +283,13 @@ export async function toolExecuteAfter(input: any, output: any) {
     } else {
       // Store state for evaluation - main LLM will decide if we continue
       setPendingEvaluation(loopSession, { ...retryLoop });
+
+      // Clear the executeReturn dedup key so the next loop continuation
+      // is not silently blocked by hasExecutedReturn check
+      const cmdItem = `/${retryLoop.commandName}${retryLoop.arguments ? " " + retryLoop.arguments : ""}`;
+      const dedupKey = `${loopSession}:${cmdItem}`;
+      deleteExecutedReturn(dedupKey);
+
       log(
         `retry: pending evaluation for condition "${retryLoop.config.until}"`
       );

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -28,7 +28,7 @@ export {
  * If no break signal found, loop continues by default (until max iterations)
  */
 export function parseLoopDecision(output: string): "break" | "continue" {
-  const match = output.match(/<subtask2\s+loop=["']?break["']?\s*\/?>/i);
+  const match = output.match(/<subtask2\s+loop\s*=\s*["']?break["']?\s*\/?>/i);
   return match ? "break" : "continue";
 }
 


### PR DESCRIPTION
Fixes:

1. **Loop continuation blocked by executeReturn dedup** — Dedup key `{sessionID}:{command}` was never cleared between loop iterations, silently blocking all continuations after the 2nd run.

2. **Duplicate prompt injection** — `setPendingPromptReturn` + `promptAsync` called together caused message-hooks to inject a duplicate user message. Removed redundant `setPendingPromptReturn`.

3. **Wrong command directory path** — Plugin looked in `command/` (singular) but OpenCode stores files in `commands/` (plural).

4. **Loop state looked up on wrong session** — Loop operations in `session.idle` used raw `sessionID` instead of resolved `targetSessionID`, missing state stored under the parent session.